### PR TITLE
ADDR 949 SyncBundleProvider never actually releases bundles

### DIFF
--- a/Advanced/Sync Addressables/Assets/SyncAddressables/Editor/SyncFastModeBuild.cs
+++ b/Advanced/Sync Addressables/Assets/SyncAddressables/Editor/SyncFastModeBuild.cs
@@ -36,7 +36,7 @@ public class SyncFastModeBuild : BuildScriptFastMode
             //create runtime data
             var aaContext = new AddressableAssetsBuildContext
             {
-                settings = aaSettings,
+                Settings = aaSettings,
                 runtimeData = new ResourceManagerRuntimeData(),
                 bundleToAssetGroup = null,
                 locations = new List<ContentCatalogDataEntry>()

--- a/Advanced/Sync Addressables/Assets/SyncAddressables/SyncBundleProvider.cs
+++ b/Advanced/Sync Addressables/Assets/SyncAddressables/SyncBundleProvider.cs
@@ -54,8 +54,6 @@ public class SyncBundleProvider : AssetBundleProvider
         if (bundle != null)
         {
             bundle.Unload();
-            return;
         }
-        return;
     }
 }

--- a/Advanced/Sync Addressables/Assets/SyncAddressables/SyncBundleProvider.cs
+++ b/Advanced/Sync Addressables/Assets/SyncAddressables/SyncBundleProvider.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections;
-using System.Collections.Generic;
 using System.ComponentModel;
 using UnityEngine;
 using UnityEngine.ResourceManagement.ResourceLocations;

--- a/Advanced/Sync Addressables/Assets/SyncAddressables/SyncBundleProvider.cs
+++ b/Advanced/Sync Addressables/Assets/SyncAddressables/SyncBundleProvider.cs
@@ -50,10 +50,7 @@ public class SyncBundleProvider : AssetBundleProvider
             Debug.LogWarningFormat("Releasing null asset bundle from location {0}.  This is an indication that the bundle failed to load.", location);
             return;
         }
-        var bundle = asset as SyncAssetBundleResource;
-        if (bundle != null)
-        {
-            bundle.Unload();
-        }
+        if (asset is SyncAssetBundleResource syncResource)
+            syncResource.Unload();
     }
 }

--- a/Advanced/Sync Addressables/Assets/spawner.cs
+++ b/Advanced/Sync Addressables/Assets/spawner.cs
@@ -1,5 +1,5 @@
-﻿using System.Collections.Generic;
-using UnityEngine;
+﻿using UnityEngine;
+using System.Collections.Generic;
 using UnityEngine.AddressableAssets;
 
 public class spawner : MonoBehaviour

--- a/Advanced/Sync Addressables/Assets/spawner.cs
+++ b/Advanced/Sync Addressables/Assets/spawner.cs
@@ -1,19 +1,39 @@
-﻿using UnityEngine;
+﻿using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.AddressableAssets;
 
 public class spawner : MonoBehaviour
 {
     int m_Counter = 0;
+    List<GameObject> m_instances = new List<GameObject>();
+
+    private void Update()
+    {
+        if (Input.GetKeyDown("space"))
+        {
+            if (m_instances.Count == 0)
+                return;
+            Debug.Log($"Release {m_instances.Count} instances");
+            foreach (var oldGo in m_instances)
+            {
+                Addressables.ReleaseInstance(oldGo);
+            }
+            m_instances.Clear();
+        }
+    }
+
     void FixedUpdate()
     {
         if (!SyncAddressables.Ready)
             return;
-        
+
         m_Counter++;
 
         if (m_Counter == 10)
         {
             var go = SyncAddressables.Instantiate("Cube");
             go.transform.forward = new Vector3(Random.Range(0, 180), Random.Range(0, 180), Random.Range(0, 180));
+            m_instances.Add(go);
         }
 
         if (m_Counter >= 60)

--- a/Advanced/Sync Addressables/Packages/manifest.json
+++ b/Advanced/Sync Addressables/Packages/manifest.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "com.unity.2d.sprite": "1.0.0",
     "com.unity.2d.tilemap": "1.0.0",
-    "com.unity.addressables": "1.3.3",
+    "com.unity.addressables": "1.9.2",
     "com.unity.ads": "2.3.1",
     "com.unity.analytics": "3.3.2",
     "com.unity.collab-proxy": "1.2.16",


### PR DESCRIPTION
https://jira.unity3d.com/browse/ADDR-949

Issue https://github.com/Unity-Technologies/Addressables-Sample/issues/19: SyncBundleProvider.Release will call parent AssetBundleProvider.Release, which fails to cast SyncAssetBundleResource as a AssetBundleResource. This occurs because while SyncBundleProvider inherits from AssetBundleProvider, SyncAssetBundleResource doesn't inherit from AssetBundleResource— they are two entirely separate classes. As a result, SyncBundleProvider never actually releases bundles. 

BundleProviders are only being used during packed mode (Use Existing Groups). 

Fix: Used user provided custom Release() and Unload() with minor tweaks.