### PR TITLE
Update SyncFastModeBuild.cs

### DIFF
--- a/Advanced/Sync Addressables/Assets/SyncAddressables/Editor/SyncFastModeBuild.cs
+++ b/Advanced/Sync Addressables/Assets/SyncAddressables/Editor/SyncFastModeBuild.cs
@@ -39,6 +39,7 @@ public class SyncFastModeBuild : BuildScriptFastMode
                 Settings = aaSettings,
                 runtimeData = new ResourceManagerRuntimeData(),
                 bundleToAssetGroup = null,
+                providerTypes=new HashSet<Type>(),
                 locations = new List<ContentCatalogDataEntry>()
             };
             aaContext.runtimeData.BuildTarget = context.Target.ToString();


### PR DESCRIPTION
in  line 96 when  assetGroup.GetSchema<PlayerDataGroupSchema>(); playerDataSchema not null 

AddressableAssetEntry  CreateCatalogEntriesInternal  732 providerTypes.Add(runtimeProvider);   providerTypes  in null error