### PR TITLE
ADDR-1689 Add exclude source object option to variants project

### DIFF
--- a/Advanced/Addressable Variants/Assets/AddressableAssetsData/AssetGroups/Schemas/PrefabGroup_PrefabTextureVariantSchema.asset
+++ b/Advanced/Addressable Variants/Assets/AddressableAssetsData/AssetGroups/Schemas/PrefabGroup_PrefabTextureVariantSchema.asset
@@ -13,6 +13,7 @@ MonoBehaviour:
   m_Name: PrefabGroup_PrefabTextureVariantSchema
   m_EditorClassIdentifier: 
   m_Group: {fileID: 11400000, guid: 760c82ba27a2fd24f8e058a22ed2d0d7, type: 2}
+  m_IncludeSourcePrefabInBuild: 1
   DefaultLabel: default
   Variants:
   - TextureScale: 0.2

--- a/Advanced/Addressable Variants/Assets/AddressableAssetsData/AssetGroups/Schemas/TextureGroup_TextureVariationSchema.asset
+++ b/Advanced/Addressable Variants/Assets/AddressableAssetsData/AssetGroups/Schemas/TextureGroup_TextureVariationSchema.asset
@@ -13,10 +13,10 @@ MonoBehaviour:
   m_Name: TextureGroup_TextureVariationSchema
   m_EditorClassIdentifier: 
   m_Group: {fileID: 11400000, guid: bac4dc0ea5af4fe47b04555b9b99b764, type: 2}
+  m_IncludeSourceTextureInBuild: 0
   m_BaselineLabel: HD
   m_Variations:
   - textureScale: 1
     label: HD
   - textureScale: 0.4
     label: SD
-  m_IncludeSourceTextureInBuild: 0

--- a/Advanced/Addressable Variants/Assets/AddressableAssetsData/AssetGroups/Schemas/TextureGroup_TextureVariationSchema.asset
+++ b/Advanced/Addressable Variants/Assets/AddressableAssetsData/AssetGroups/Schemas/TextureGroup_TextureVariationSchema.asset
@@ -19,3 +19,4 @@ MonoBehaviour:
     label: HD
   - textureScale: 0.4
     label: SD
+  m_IncludeSourceTextureInBuild: 0

--- a/Advanced/Addressable Variants/Assets/Editor/BuildScriptInherited.cs
+++ b/Advanced/Addressable Variants/Assets/Editor/BuildScriptInherited.cs
@@ -268,7 +268,7 @@ public class BuildScriptInherited : BuildScriptPackedMode, ISerializationCallbac
             }
         }
 
-        if (assetGroup.HasSchema<BundledAssetGroupSchema>())
+        if (!schema.IncludeSourceTextureInBuild && assetGroup.HasSchema<BundledAssetGroupSchema>())
         {
             var bundledSchema = assetGroup.GetSchema<BundledAssetGroupSchema>();
             m_SourceGroupToIncludeInBuildFlag.Add(assetGroup, bundledSchema.IncludeInBuild);
@@ -338,7 +338,7 @@ public class BuildScriptInherited : BuildScriptPackedMode, ISerializationCallbac
             if (schema == null)
                 continue;
             
-            if (pair.Key.HasSchema<BundledAssetGroupSchema>())
+            if (!schema.IncludeSourceTextureInBuild && pair.Key.HasSchema<BundledAssetGroupSchema>())
                 pair.Key.GetSchema<BundledAssetGroupSchema>().IncludeInBuild = pair.Value;
 
             foreach (var entry in pair.Key.entries)

--- a/Advanced/Addressable Variants/Assets/Editor/PrefabTextureVariantSchema.cs
+++ b/Advanced/Addressable Variants/Assets/Editor/PrefabTextureVariantSchema.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEditor;
@@ -8,6 +8,15 @@ using UnityEngine.AddressableAssets;
 
 public class PrefabTextureVariantSchema : AddressableAssetGroupSchema
 {
+    [SerializeField]
+    [Tooltip("If true, the source prefab and its variants will be included in the build. Otherwise only the variants will be included.")]
+    bool m_IncludeSourcePrefabInBuild = false;
+    public bool IncludeSourcePrefabInBuild
+    {
+        get { return m_IncludeSourcePrefabInBuild; }
+        set { m_IncludeSourcePrefabInBuild = value; }
+    }
+
     [Serializable]
     public struct VariantLabelPair
     {

--- a/Advanced/Addressable Variants/Assets/Editor/TextureVariationSchema.cs
+++ b/Advanced/Addressable Variants/Assets/Editor/TextureVariationSchema.cs
@@ -7,6 +7,14 @@ using UnityEngine.Serialization;
 
 public class TextureVariationSchema : AddressableAssetGroupSchema
 {
+    [SerializeField]
+    [Tooltip("If true, the source texture and its variants will be included in the build. Otherwise only the variants will be included.")]
+    bool m_IncludeSourceTextureInBuild = false;
+    public bool IncludeSourceTextureInBuild
+    {
+        get { return m_IncludeSourceTextureInBuild; }
+        set { m_IncludeSourceTextureInBuild = value; }
+    }
 
     [SerializeField]
     string m_BaselineLabel = "HD";
@@ -29,14 +37,5 @@ public class TextureVariationSchema : AddressableAssetGroupSchema
     {
         public float textureScale = 0.5f;
         public string label;
-    }
-
-    [SerializeField]
-    [Tooltip("If true, the source texture and its variants will be included in the build. Otherwise only the variants will be included.")]
-    bool m_IncludeSourceTextureInBuild = false;
-    public bool IncludeSourceTextureInBuild
-    {
-        get { return m_IncludeSourceTextureInBuild; }
-        set { m_IncludeSourceTextureInBuild = value; }
     }
 }

--- a/Advanced/Addressable Variants/Assets/Editor/TextureVariationSchema.cs
+++ b/Advanced/Addressable Variants/Assets/Editor/TextureVariationSchema.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEditor.AddressableAssets.Settings;
@@ -30,5 +30,13 @@ public class TextureVariationSchema : AddressableAssetGroupSchema
         public float textureScale = 0.5f;
         public string label;
     }
-    
+
+    [SerializeField]
+    [Tooltip("If true, the source texture and its variants will be included in the build. Otherwise only the variants will be included.")]
+    bool m_IncludeSourceTextureInBuild = false;
+    public bool IncludeSourceTextureInBuild
+    {
+        get { return m_IncludeSourceTextureInBuild; }
+        set { m_IncludeSourceTextureInBuild = value; }
+    }
 }


### PR DESCRIPTION
- Any groups that use the texture or prefab variant schema, must also have a bundled asset group schema with their "IncludeInBuild" flag enabled. If disabled, neither the original source group or its variant groups will be included in the build.

- Added option "IncludeSourceTextureInBuild" to the texture variant schema.  Disabled by default. 
If the option is disabled, the custom build script will temporarily disable the bundled asset group schema "IncludeInBuild" flag to exclude the original source texture group from the build.
![image](https://user-images.githubusercontent.com/51127400/139296540-285139e0-b451-4cc1-9531-45b864abdbe9.png)

- Added option "IncludeSourcePrefabInBuild" to the prefab variant schema.  Disabled by default, but since the sample project expects to load the source prefab it is enabled in the project. 
If the option is disabled, the custom build script will temporarily disable the bundled asset group schema "IncludeInBuild" flag to exclude the original source prefab group from the build.
![image](https://user-images.githubusercontent.com/51127400/139296581-c1089fc5-f97d-421c-955d-28f047767ca4.png)