### PR TITLE
ADDR-2596 Mark asset as dirty when name or delivery type changes

### DIFF
--- a/Advanced/Play Asset Delivery/Assets/PlayAssetDelivery/Editor/CustomAssetPackSettings.cs
+++ b/Advanced/Play Asset Delivery/Assets/PlayAssetDelivery/Editor/CustomAssetPackSettings.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text.RegularExpressions;
 using UnityEditor;
 using UnityEngine;
 
@@ -32,6 +33,8 @@ namespace AddressablesPlayAssetDelivery.Editor
         public static string kDefaultPackName = "AssetPack";
         public static DeliveryType kDefaultDeliveryType = DeliveryType.OnDemand;
 
+        private Regex m_ValidAssetPackName = new Regex(@"^[A-Za-z][a-zA-Z0-9_]*$", RegexOptions.Compiled);
+
         public static string kDefaultSettingsPath
         {
             get
@@ -61,6 +64,33 @@ namespace AddressablesPlayAssetDelivery.Editor
         {
             string assetPackName = GenerateUniqueName(kDefaultPackName, CustomAssetPacks.Select(p => p.AssetPackName));
             AddCustomAssetPack(assetPackName, kDefaultDeliveryType);
+        }
+
+        public void SetAssetPackName(int index, string assetPackName)
+        {
+            if (index >= 0 && index < CustomAssetPacks.Count)
+            {
+                if (!m_ValidAssetPackName.IsMatch(assetPackName))
+                {
+                    Debug.LogError($"Cannot name custom asset pack '{assetPackName}'. All characters must be alphanumeric or an underscore. " +
+                        $"Also the first character must be a letter.");
+                }
+                else
+                {
+                    string newName = GenerateUniqueName(assetPackName, CustomAssetPacks.Select(p => p.AssetPackName));
+                    CustomAssetPacks[index].AssetPackName = newName;
+                    EditorUtility.SetDirty(this);
+                }
+            }
+        }
+
+        public void SetDeliveryType(int index, DeliveryType deliveryType)
+        {
+            if (index >= 0 && index < CustomAssetPacks.Count)
+            {
+                CustomAssetPacks[index].DeliveryType = deliveryType;
+                EditorUtility.SetDirty(this);
+            }
         }
 
         internal string GenerateUniqueName(string baseName, IEnumerable<string> enumerable)

--- a/Advanced/Play Asset Delivery/Assets/PlayAssetDelivery/Editor/CustomAssetPackSettingsInspector.cs
+++ b/Advanced/Play Asset Delivery/Assets/PlayAssetDelivery/Editor/CustomAssetPackSettingsInspector.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Linq;
-using System.Text.RegularExpressions;
 using UnityEditor;
 using UnityEditorInternal;
 using UnityEngine;
@@ -13,8 +12,6 @@ namespace AddressablesPlayAssetDelivery.Editor
         CustomAssetPackSettings m_Settings;
         [SerializeField]
         ReorderableList m_CustomAssetPacks;
-
-        Regex m_ValidAssetPackName = new Regex(@"^[A-Za-z][a-zA-Z0-9_]*$", RegexOptions.Compiled);
 
         void OnEnable()
         {
@@ -44,23 +41,12 @@ namespace AddressablesPlayAssetDelivery.Editor
             string oldName = currentAssetPack.AssetPackName;
             var newName = EditorGUI.DelayedTextField(new Rect(rect.x, rect.y, halfW, rect.height), oldName);
             if (newName != oldName)
-            {
-                if (!m_ValidAssetPackName.IsMatch(newName))
-                {
-                    Debug.LogError($"Cannot name custom asset pack '{newName}'. All characters must be alphanumeric or an underscore. " +
-                        $"Also the first character must be a letter.");
-                }
-                else
-                {
-                    newName = m_Settings.GenerateUniqueName(newName, m_Settings.CustomAssetPacks.Select(p => p.AssetPackName));
-                    currentAssetPack.AssetPackName = newName;
-                }
-            }
+                m_Settings.SetAssetPackName(index, newName);
 
             DeliveryType oldType = currentAssetPack.DeliveryType;
             var newType = (DeliveryType)EditorGUI.EnumPopup(new Rect(rect.x + halfW, rect.y, rect.width - halfW, rect.height), new GUIContent(""), oldType, IsDeliveryTypeEnabled);
             if (oldType != newType)
-                currentAssetPack.DeliveryType = newType;
+                m_Settings.SetDeliveryType(index, newType);
 
             EditorGUI.EndDisabledGroup();
         }


### PR DESCRIPTION
Fixed issue where CustomPackSettings fields (asset pack name & delivery type) aren't being serialized.
Move asset pack name validation code to CustomPackSettings.