### PR TITLE
ADDR-2589 Building app bundle FileNotFoundException 2021.2+

### DIFF
--- a/Advanced/Play Asset Delivery/Assets/PlayAssetDelivery/Editor/PlayAssetDeliveryBuildProcessor.cs
+++ b/Advanced/Play Asset Delivery/Assets/PlayAssetDelivery/Editor/PlayAssetDeliveryBuildProcessor.cs
@@ -33,7 +33,7 @@ namespace AddressablesPlayAssetDelivery.Editor
         /// <param name="buildPlayerContext">Contains data related to the player.</param>
         public override void PrepareForBuild(BuildPlayerContext buildPlayerContext)
         {
-           if (EditorUserBuildSettings.activeBuildTarget == BuildTarget.Android && EditorUserBuildSettings.buildAppBundle)
+            if (EditorUserBuildSettings.activeBuildTarget == BuildTarget.Android && EditorUserBuildSettings.buildAppBundle)
                 MoveDataForAppBundleBuild(buildPlayerContext);
             else
                 MoveDataToDefaultLocation();
@@ -48,7 +48,7 @@ namespace AddressablesPlayAssetDelivery.Editor
             try
             {
                 buildPlayerContext.AddAdditionalPathToStreamingAssets(CustomAssetPackUtility.CustomAssetPacksDataEditorPath, CustomAssetPackUtility.kCustomAssetPackDataFilename);
-                
+
                 AssetDatabase.StartAssetEditing();
                 if (File.Exists(CustomAssetPackUtility.BuildProcessorDataPath))
                 {

--- a/Advanced/Play Asset Delivery/Assets/PlayAssetDelivery/Editor/PlayAssetDeliveryBuildProcessor.cs
+++ b/Advanced/Play Asset Delivery/Assets/PlayAssetDelivery/Editor/PlayAssetDeliveryBuildProcessor.cs
@@ -10,6 +10,108 @@ using UnityEngine;
 
 namespace AddressablesPlayAssetDelivery.Editor
 {
+#if UNITY_2021_2_OR_NEWER
+    /// <summary>
+    /// Moves custom asset pack data from their default build location <see cref="BuildScriptPlayAssetDelivery"/> to their correct player build data location.
+    /// For an Android App Bundle, bundles assigned to a custom asset pack must be located in their {asset pack name}.androidpack directory in the Assets folder.
+    /// The 'CustomAssetPacksData.json' file is also added to the built player's StreamingAssets file location.
+    ///
+    /// This script executes before the <see cref="AddressablesPlayerBuildProcessor"/> which moves all Addressables data to StreamingAssets.
+    public class PlayAssetDeliveryBuildProcessor : BuildPlayerProcessor
+    {
+        /// <summary>
+        /// Returns the player build processor callback order.
+        /// </summary>
+        public override int callbackOrder
+        {
+            get { return 0; }
+        }
+
+        /// <summary>
+        /// Invoked before performing a Player build. Maintains building Addressables step and processing Addressables build data.
+        /// </summary>
+        /// <param name="buildPlayerContext">Contains data related to the player.</param>
+        public override void PrepareForBuild(BuildPlayerContext buildPlayerContext)
+        {
+           if (EditorUserBuildSettings.activeBuildTarget == BuildTarget.Android && EditorUserBuildSettings.buildAppBundle)
+                MoveDataForAppBundleBuild(buildPlayerContext);
+            else
+                MoveDataToDefaultLocation();
+        }
+
+        /// <summary>
+        /// Move custom asset pack data from their build location to their App Bundle data location.
+        /// </summary>
+        /// <param name="buildPlayerContext">Contains data related to the player.</param>
+        public static void MoveDataForAppBundleBuild(BuildPlayerContext buildPlayerContext)
+        {
+            try
+            {
+                buildPlayerContext.AddAdditionalPathToStreamingAssets(CustomAssetPackUtility.CustomAssetPacksDataEditorPath, CustomAssetPackUtility.kCustomAssetPackDataFilename);
+                
+                AssetDatabase.StartAssetEditing();
+                if (File.Exists(CustomAssetPackUtility.BuildProcessorDataPath))
+                {
+                    string contents = File.ReadAllText(CustomAssetPackUtility.BuildProcessorDataPath);
+                    var data =  JsonUtility.FromJson<BuildProcessorData>(contents);
+
+                    foreach (BuildProcessorDataEntry entry in data.Entries)
+                    {
+                        string assetsFolderPath = Path.Combine(CustomAssetPackUtility.PackContentRootDirectory, entry.AssetsSubfolderPath);
+                        if (File.Exists(entry.BundleBuildPath))
+                        {
+                            File.Move(entry.BundleBuildPath, assetsFolderPath);
+                            File.Delete(entry.BundleBuildPath + ".meta");
+                        }
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                Debug.LogError($"Exception occured when moving data for an app bundle build: {e.Message}.");
+            }
+            finally
+            {
+                AssetDatabase.StopAssetEditing();
+            }
+        }
+
+        /// <summary>
+        /// Move custom asset pack data from their App Bundle data location to to their build location.
+        /// </summary>
+        public static void MoveDataToDefaultLocation()
+        {
+            try
+            {
+                AssetDatabase.StartAssetEditing();
+
+                if (File.Exists(CustomAssetPackUtility.BuildProcessorDataPath))
+                {
+                    string contents = File.ReadAllText(CustomAssetPackUtility.BuildProcessorDataPath);
+                    var data =  JsonUtility.FromJson<BuildProcessorData>(contents);
+
+                    foreach (BuildProcessorDataEntry entry in data.Entries)
+                    {
+                        string assetsFolderPath = Path.Combine(CustomAssetPackUtility.PackContentRootDirectory, entry.AssetsSubfolderPath);
+                        if (File.Exists(assetsFolderPath))
+                        {
+                            File.Move(assetsFolderPath, entry.BundleBuildPath);
+                            File.Delete(assetsFolderPath + ".meta");
+                        }
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                Debug.LogError($"Exception occured when moving data for a player build: {e.Message}.");
+            }
+            finally
+            {
+                AssetDatabase.StopAssetEditing();
+            }
+        }
+    }
+#else
     /// <summary>
     /// Moves custom asset pack data from their default build location <see cref="BuildScriptPlayAssetDelivery"/> to their correct player build data location.
     /// For an Android App Bundle, bundles assigned to a custom asset pack must be located in their {asset pack name}.androidpack directory in the Assets folder.
@@ -121,4 +223,5 @@ namespace AddressablesPlayAssetDelivery.Editor
             }
         }
     }
+#endif
 }

--- a/Advanced/Play Asset Delivery/Assets/PlayAssetDelivery/Editor/PlayAssetDeliveryBuildProcessor.cs
+++ b/Advanced/Play Asset Delivery/Assets/PlayAssetDelivery/Editor/PlayAssetDeliveryBuildProcessor.cs
@@ -60,8 +60,9 @@ namespace AddressablesPlayAssetDelivery.Editor
                         string assetsFolderPath = Path.Combine(CustomAssetPackUtility.PackContentRootDirectory, entry.AssetsSubfolderPath);
                         if (File.Exists(entry.BundleBuildPath))
                         {
+                            string metaFilePath = AssetDatabase.GetTextMetaFilePathFromAssetPath(entry.BundleBuildPath);
                             File.Move(entry.BundleBuildPath, assetsFolderPath);
-                            File.Delete(entry.BundleBuildPath + ".meta");
+                            File.Delete(metaFilePath);
                         }
                     }
                 }
@@ -95,8 +96,9 @@ namespace AddressablesPlayAssetDelivery.Editor
                         string assetsFolderPath = Path.Combine(CustomAssetPackUtility.PackContentRootDirectory, entry.AssetsSubfolderPath);
                         if (File.Exists(assetsFolderPath))
                         {
+                            string metaFilePath = AssetDatabase.GetTextMetaFilePathFromAssetPath(assetsFolderPath);
                             File.Move(assetsFolderPath, entry.BundleBuildPath);
-                            File.Delete(assetsFolderPath + ".meta");
+                            File.Delete(metaFilePath);
                         }
                     }
                 }
@@ -153,8 +155,9 @@ namespace AddressablesPlayAssetDelivery.Editor
                 {
                     if (!Directory.Exists(Application.streamingAssetsPath))
                         Directory.CreateDirectory(Application.streamingAssetsPath);
+                    string metaFilePath = AssetDatabase.GetTextMetaFilePathFromAssetPath(CustomAssetPackUtility.CustomAssetPacksDataEditorPath);
                     File.Move(CustomAssetPackUtility.CustomAssetPacksDataEditorPath, CustomAssetPackUtility.CustomAssetPacksDataRuntimePath);
-                    File.Delete(CustomAssetPackUtility.CustomAssetPacksDataEditorPath + ".meta");
+                    File.Delete(metaFilePath);
                 }
                 if (File.Exists(CustomAssetPackUtility.BuildProcessorDataPath))
                 {
@@ -166,8 +169,9 @@ namespace AddressablesPlayAssetDelivery.Editor
                         string assetsFolderPath = Path.Combine(CustomAssetPackUtility.PackContentRootDirectory, entry.AssetsSubfolderPath);
                         if (File.Exists(entry.BundleBuildPath))
                         {
+                            string metaFilePath = AssetDatabase.GetTextMetaFilePathFromAssetPath(entry.BundleBuildPath);
                             File.Move(entry.BundleBuildPath, assetsFolderPath);
-                            File.Delete(entry.BundleBuildPath + ".meta");
+                            File.Delete(metaFilePath);
                         }
                     }
                 }
@@ -193,8 +197,9 @@ namespace AddressablesPlayAssetDelivery.Editor
 
                 if (File.Exists(CustomAssetPackUtility.CustomAssetPacksDataRuntimePath))
                 {
+                    string metaFilePath = AssetDatabase.GetTextMetaFilePathFromAssetPath(CustomAssetPackUtility.CustomAssetPacksDataRuntimePath);
                     File.Move(CustomAssetPackUtility.CustomAssetPacksDataRuntimePath, CustomAssetPackUtility.CustomAssetPacksDataEditorPath);
-                    File.Delete(CustomAssetPackUtility.CustomAssetPacksDataRuntimePath + ".meta");
+                    File.Delete(metaFilePath);
                     CustomAssetPackUtility.DeleteDirectory(Application.streamingAssetsPath, true);
                 }
                 if (File.Exists(CustomAssetPackUtility.BuildProcessorDataPath))
@@ -207,8 +212,9 @@ namespace AddressablesPlayAssetDelivery.Editor
                         string assetsFolderPath = Path.Combine(CustomAssetPackUtility.PackContentRootDirectory, entry.AssetsSubfolderPath);
                         if (File.Exists(assetsFolderPath))
                         {
+                            string metaFilePath = AssetDatabase.GetTextMetaFilePathFromAssetPath(assetsFolderPath);
                             File.Move(assetsFolderPath, entry.BundleBuildPath);
-                            File.Delete(assetsFolderPath + ".meta");
+                            File.Delete(metaFilePath);
                         }
                     }
                 }

--- a/Advanced/Play Asset Delivery/Assets/PlayAssetDelivery/Editor/PlayAssetDeliveryBuildProcessor.cs
+++ b/Advanced/Play Asset Delivery/Assets/PlayAssetDelivery/Editor/PlayAssetDeliveryBuildProcessor.cs
@@ -28,7 +28,7 @@ namespace AddressablesPlayAssetDelivery.Editor
         }
 
         /// <summary>
-        /// Invoked before performing a Player build. Maintains building Addressables step and processing Addressables build data.
+        /// Invoked before performing a Player build. Moves AssetBundles to their correct data location based on the build target platform.
         /// </summary>
         /// <param name="buildPlayerContext">Contains data related to the player.</param>
         public override void PrepareForBuild(BuildPlayerContext buildPlayerContext)
@@ -130,7 +130,7 @@ namespace AddressablesPlayAssetDelivery.Editor
         }
 
         ///<summary>
-        /// Initializes temporary build data.
+        /// Invoked before performing a Player build. Moves AssetBundles to their correct data location based on the build target platform.
         /// </summary>
         public void OnPreprocessBuild(BuildReport report)
         {


### PR DESCRIPTION
BuildPlayerProcessor callbacks run first before the IPreprocessBuildWithReport callbacks, causing the AddressablesPlayerBuildProcessor code to run before PlayAssetDeliveryBuildProcessor.

Added a new code path for 21.2+ in PlayAssetDeliveryBuildProcessor that uses the same new BuildPlayerProcessor API.