### PR TITLE
Fixed the default type of object that ODRBundleProvider supports

### DIFF
--- a/Advanced/On-Demand Resources/Assets/AdrOdrExt/Runtime/ODRBundleProvider.cs
+++ b/Advanced/On-Demand Resources/Assets/AdrOdrExt/Runtime/ODRBundleProvider.cs
@@ -68,7 +68,7 @@ namespace UnityEngine.ResourceManagement.ResourceProviders
         /// <inheritdoc/>
         public override Type GetDefaultType(IResourceLocation location)
         {
-            return typeof(ODRAssetBundleResource);
+            return typeof(IAssetBundleResource);
         }
 
         /// <summary>


### PR DESCRIPTION
`GetDefaultType` should return the inheritable base type (i.e. `IAssetBundleResource`) instead of the inherited type (i.e. `ODRAssetBundleResource`).