### PR TITLE
On-Demand Resources: Added functionality to apply prefetch categories to Addressables groups

### DIFF
--- a/Advanced/On-Demand Resources/Assets/AddressableAssetsData/AssetGroups/Schemas/pack_d_AppleODRSchema.asset
+++ b/Advanced/On-Demand Resources/Assets/AddressableAssetsData/AssetGroups/Schemas/pack_d_AppleODRSchema.asset
@@ -13,5 +13,7 @@ MonoBehaviour:
   m_Name: pack_d_AppleODRSchema
   m_EditorClassIdentifier: 
   m_Group: {fileID: 11400000, guid: a9cbeb263f29246fcb5b9413cb69beb7, type: 2}
+  m_prefetchCategory: 0
+  m_order: 0
   m_BuildPath:
     m_Id: a7070c84fc67c4384b42419195dcee13

--- a/Advanced/On-Demand Resources/Assets/AddressableAssetsData/AssetGroups/Schemas/pack_e_AppleODRSchema.asset
+++ b/Advanced/On-Demand Resources/Assets/AddressableAssetsData/AssetGroups/Schemas/pack_e_AppleODRSchema.asset
@@ -13,5 +13,7 @@ MonoBehaviour:
   m_Name: pack_e_AppleODRSchema
   m_EditorClassIdentifier: 
   m_Group: {fileID: 11400000, guid: 27577b1f1eb80442aa0b36a2cb468bab, type: 2}
+  m_prefetchCategory: 0
+  m_order: 0
   m_BuildPath:
     m_Id: a7070c84fc67c4384b42419195dcee13

--- a/Advanced/On-Demand Resources/Assets/AddressableAssetsData/AssetGroups/Schemas/pack_f_AppleODRSchema.asset
+++ b/Advanced/On-Demand Resources/Assets/AddressableAssetsData/AssetGroups/Schemas/pack_f_AppleODRSchema.asset
@@ -13,5 +13,7 @@ MonoBehaviour:
   m_Name: pack_f_AppleODRSchema
   m_EditorClassIdentifier: 
   m_Group: {fileID: 11400000, guid: 367da7168bca646ffb7d98f87f2d872d, type: 2}
+  m_prefetchCategory: 0
+  m_order: 0
   m_BuildPath:
     m_Id: a7070c84fc67c4384b42419195dcee13

--- a/Advanced/On-Demand Resources/Assets/AddressableAssetsData/AssetGroups/Schemas/pack_g_AppleODRSchema.asset
+++ b/Advanced/On-Demand Resources/Assets/AddressableAssetsData/AssetGroups/Schemas/pack_g_AppleODRSchema.asset
@@ -13,5 +13,7 @@ MonoBehaviour:
   m_Name: pack_g_AppleODRSchema
   m_EditorClassIdentifier: 
   m_Group: {fileID: 11400000, guid: d927d0430d285434598a4c39f1c68931, type: 2}
+  m_prefetchCategory: 1
+  m_order: 3
   m_BuildPath:
     m_Id: a7070c84fc67c4384b42419195dcee13

--- a/Advanced/On-Demand Resources/Assets/AddressableAssetsData/AssetGroups/Schemas/pack_h_AppleODRSchema.asset
+++ b/Advanced/On-Demand Resources/Assets/AddressableAssetsData/AssetGroups/Schemas/pack_h_AppleODRSchema.asset
@@ -13,5 +13,7 @@ MonoBehaviour:
   m_Name: pack_h_AppleODRSchema
   m_EditorClassIdentifier: 
   m_Group: {fileID: 11400000, guid: c7fcc31dd72734b32ae7874a778246f4, type: 2}
+  m_prefetchCategory: 1
+  m_order: 2
   m_BuildPath:
     m_Id: a7070c84fc67c4384b42419195dcee13

--- a/Advanced/On-Demand Resources/Assets/AddressableAssetsData/AssetGroups/Schemas/pack_i_AppleODRSchema.asset
+++ b/Advanced/On-Demand Resources/Assets/AddressableAssetsData/AssetGroups/Schemas/pack_i_AppleODRSchema.asset
@@ -13,5 +13,7 @@ MonoBehaviour:
   m_Name: pack_i_AppleODRSchema
   m_EditorClassIdentifier: 
   m_Group: {fileID: 11400000, guid: 0ed893044bb394073875fa7eee1b3e70, type: 2}
+  m_prefetchCategory: 1
+  m_order: 1
   m_BuildPath:
     m_Id: a7070c84fc67c4384b42419195dcee13

--- a/Advanced/On-Demand Resources/Assets/AdrOdrExt/Editor/Build/PostProcess.meta
+++ b/Advanced/On-Demand Resources/Assets/AdrOdrExt/Editor/Build/PostProcess.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: cc3721aaf1e2b4732a421ada4e6e51cd
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Advanced/On-Demand Resources/Assets/AdrOdrExt/Editor/Build/PostProcess/PostProcessODRBundles.cs
+++ b/Advanced/On-Demand Resources/Assets/AdrOdrExt/Editor/Build/PostProcess/PostProcessODRBundles.cs
@@ -28,12 +28,12 @@ public class PostProcessODRBundles : IPostprocessBuildWithReport
         
         // Initial Install Tags
         var initialTags = categories[(int)AppleODRSchema.PrefetchCategory.InitialInstallTags];
-        var initialTagsValue = initialTags.Count > 0 ? string.Join(" ", initialTags) : "";
+        var initialTagsValue = string.Join(" ", initialTags);
         pbxProject.SetBuildProperty(mainTargetGuid, InitialInstallTagsKey, initialTagsValue);
         
         // Prefetched Tag Order
         var prefetchedTags = categories[(int)AppleODRSchema.PrefetchCategory.PrefetchedTagOrder];
-        var prefetchedTagsValue = prefetchedTags.Count > 0 ? string.Join(" ", prefetchedTags) : "";
+        var prefetchedTagsValue = string.Join(" ", prefetchedTags);
         pbxProject.SetBuildProperty(mainTargetGuid, PrefetchedTagOrderKey, prefetchedTagsValue);
         
         // Apply changes to the PBXProject

--- a/Advanced/On-Demand Resources/Assets/AdrOdrExt/Editor/Build/PostProcess/PostProcessODRBundles.cs
+++ b/Advanced/On-Demand Resources/Assets/AdrOdrExt/Editor/Build/PostProcess/PostProcessODRBundles.cs
@@ -1,0 +1,43 @@
+#if UNITY_IOS
+using System;
+using UnityEditor;
+using UnityEditor.AddressableAssets.Build.DataBuilders;
+using UnityEditor.Build;
+using UnityEditor.Build.Reporting;
+using UnityEditor.iOS.Xcode;
+using UnityEngine;
+
+public class PostProcessODRBundles : IPostprocessBuildWithReport
+{
+    public int callbackOrder { get { return 10; } }
+
+    private const string InitialInstallTagsKey = "ON_DEMAND_RESOURCES_INITIAL_INSTALL_TAGS";
+    private const string PrefetchedTagOrderKey = "ON_DEMAND_RESOURCES_PREFETCH_ORDER";
+
+    public void OnPostprocessBuild(BuildReport report)
+    {
+        // Initialize PBXProject
+        var pathToBuiltProject = report.summary.outputPath;
+        string projectPath = PBXProject.GetPBXProjectPath(pathToBuiltProject);
+        PBXProject pbxProject = new PBXProject();
+        pbxProject.ReadFromFile(projectPath);
+        
+        // Set Prefetch Categories
+        string mainTargetGuid = pbxProject.GetUnityMainTargetGuid();
+        var categories = BuildScriptPackedModeODR.CollectPrefetchCategories();
+        
+        // Initial Install Tags
+        var initialTags = categories[(int)AppleODRSchema.PrefetchCategory.InitialInstallTags];
+        var initialTagsValue = initialTags.Count > 0 ? string.Join(" ", initialTags) : "";
+        pbxProject.SetBuildProperty(mainTargetGuid, InitialInstallTagsKey, initialTagsValue);
+        
+        // Prefetched Tag Order
+        var prefetchedTags = categories[(int)AppleODRSchema.PrefetchCategory.PrefetchedTagOrder];
+        var prefetchedTagsValue = prefetchedTags.Count > 0 ? string.Join(" ", prefetchedTags) : "";
+        pbxProject.SetBuildProperty(mainTargetGuid, PrefetchedTagOrderKey, prefetchedTagsValue);
+        
+        // Apply changes to the PBXProject
+        pbxProject.WriteToFile(projectPath);
+    }
+}
+#endif

--- a/Advanced/On-Demand Resources/Assets/AdrOdrExt/Editor/Build/PostProcess/PostProcessODRBundles.cs.meta
+++ b/Advanced/On-Demand Resources/Assets/AdrOdrExt/Editor/Build/PostProcess/PostProcessODRBundles.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9ceb7a307c1e0484da48c646c2ae1515
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Advanced/On-Demand Resources/Assets/AdrOdrExt/Editor/Settings/AppleODRSchema.cs
+++ b/Advanced/On-Demand Resources/Assets/AdrOdrExt/Editor/Settings/AppleODRSchema.cs
@@ -7,10 +7,42 @@ using UnityEngine.Serialization;
 [DisplayName("Apple ODR Schema")]
 public class AppleODRSchema : AddressableAssetGroupSchema
 {
+    public enum PrefetchCategory
+    {
+        InitialInstallTags,
+        PrefetchedTagOrder,
+        DownloadOnlyOnDemand
+    }
+    
+    [SerializeField]
+    [Tooltip("Bundle prefetch behaviour.")]
+    PrefetchCategory m_prefetchCategory = PrefetchCategory.DownloadOnlyOnDemand;
+    
+    /// <summary>
+    /// On Demand Resources prefetch behaviour.
+    /// </summary>
+    public PrefetchCategory Category
+    {
+        get { return m_prefetchCategory; }
+    }
+    
+    [SerializeField]
+    [Tooltip("Bundle download order (only applies when using Prefetched Tag Order).")]
+    int m_order = 0;
+    
+    /// <summary>
+    /// Bundle download order (only applies when using Prefetched Tag Order).
+    /// </summary>
+    public int Order
+    {
+        get { return m_order; }
+    }
+    
     [FormerlySerializedAs("m_buildPath")]
     [SerializeField]
     [Tooltip("The path to copy asset bundles to.")]
     ProfileValueReference m_BuildPath = new ProfileValueReference();
+    
     /// <summary>
     /// The path to copy asset bundles to.
     /// </summary>


### PR DESCRIPTION
Apple uses [Prefetch Categories](https://developer.apple.com/library/archive/documentation/FileManagement/Conceptual/On_Demand_Resources_Guide/Tagging.html#//apple_ref/doc/uid/TP40015083-CH3-SW1) to define when On-Demand Resources (ODRs) are downloaded.

Main changes:
- You can now specify the prefetch category used by each Addressables group via the AppleODRSchema component.
- Each ODR now uses the name of the Addressables group as its tag (conforms with Apple's approach to grouping tags).
- Added post-process script that applies the specified prefetch category (and order) in the Xcode project.

The example Addressables groups in the project have also been modified to use different prefetch categories:
- Packs D, E, F: Initial Install Tags
- Packs G, H, I: Prefetched Tag Order
- Packs J, K, L: Download Only On Demand